### PR TITLE
feat: add support for processing Gitea repositories, like opendev.org

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,21 +9,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.20']
-    
+        go: ['1.21']
+
     name: Go ${{ matrix.go }}
     steps:
       - uses: actions/checkout@v3
-    
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-    
+
       - name: Test and build
         run: |
           go test -race ./... -check.vv

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,23 @@ on:
     branches: [ main ]
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    name: Format check
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Ensure no formatting changes
+      run: |
+        go fmt ./...
+        git diff --exit-code
+
   build:
     runs-on: ubuntu-latest
 
@@ -28,20 +45,3 @@ jobs:
         run: |
           go test -race ./... -check.vv
           go build ./cmd/releasegen
-
-  format:
-    runs-on: ubuntu-latest
-
-    name: Format check
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: 'go.mod'
-
-    - name: Ensure no formatting changes
-      run: |
-        go fmt ./...
-        git diff --exit-code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.20']
+    
+    name: Go ${{ matrix.go }}
+    steps:
+      - uses: actions/checkout@v3
+    
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+    
+      - name: Test and build
+        run: |
+          go test -race ./... -check.vv
+          go build ./cmd/releasegen
+
+  format:
+    runs-on: ubuntu-latest
+
+    name: Format check
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Ensure no formatting changes
+      run: |
+        go fmt ./...
+        git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 releasegen.yaml
+releasegen
 dist/
 __debug_bin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+exclude: lib
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: requirements-txt-fixer
+    -   id: check-shebang-scripts-are-executable
+    -   id: check-symlinks
+  - repo: https://github.com/Bahjat/pre-commit-golang
+    rev: v1.0.3
+    hooks:
+      - id: go-fmt-import
+      - id: go-vet
+      - id: go-lint
+      - id: go-unit-tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # releasegen
 
-This is a tool used for generating JSON reports containing details about Github and Launchpad
-version control repositories.
+This is a tool used for generating JSON reports containing details about Github, Launchpad, and
+Gitea version control repositories.
 
 ## Why?
 
@@ -22,8 +22,8 @@ to generate the static site.
 ## Usage
 
 ```
-releasegen is a utility for enumerating Github and Launchpad releases/tags from
-specified Github Organisations or Launchpad project groups.
+releasegen is a utility for enumerating Github, Launchpad, and Gitea releases/tags from
+specified Github Organisations, Launchpad project groups, and Gitea Organisations.
 
 This tool is configured using a single file in one of the three following locations:
 
@@ -96,6 +96,20 @@ teams:
       project-groups:
         - <project group>
         - <project group>
+
+    # (Optional) Gitea configuration for the team
+    gitea:
+      # (Required) The name of a Gitea Organisation
+      - org: <gitea organisation name>
+
+        # (Required) The URL of the Gitea instance, e.g. `https://opendev.org/`
+        url: <URL for the Gitea instance>
+
+        # (Optional) A list of repository names to ignore
+        ignores:
+          # List of repo names
+          - <repo>
+          - <repo>
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -105,7 +105,18 @@ teams:
         # (Required) The URL of the Gitea instance, e.g. `https://opendev.org/`
         url: <URL for the Gitea instance>
 
+        # (Optional) A list of repository names to include
+        # If empty, all public, non-archived repositories in the org will be
+        # included, unless listed in `ignores`.
+        includes:
+          # List of repo names
+          - <repo>:
+            monorepo-folders: ['<folder name>', <'folder name'>]
+          - <repo>
+            monorepo-folders: []
+
         # (Optional) A list of repository names to ignore
+        # Ignored if `includes` is not empty.
         ignores:
           # List of repo names
           - <repo>

--- a/cmd/releasegen/main.go
+++ b/cmd/releasegen/main.go
@@ -19,9 +19,10 @@ var (
 )
 
 const (
-	shortDesc = "releasegen - a utility for enumerating Github and Launchpad releases"
-	longDesc  = ` releasegen is a utility for enumerating Github and Launchpad releases/tags
-from specified Github Organisations or Launchpad project groups.
+	shortDesc = "releasegen - a utility for enumerating Github, Launchpad, and Gitea releases"
+	longDesc  = ` releasegen is a utility for enumerating Github, Launchpad, and Gitea
+releases/tags from specified Github Organisations, Launchpad project groups, or Gitea
+organisations.
 
 This tool is configured using a single file in one of the three following locations:
 

--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,16 @@ require (
 )
 
 require (
+	code.gitea.io/sdk/gitea v0.17.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95 // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/hashicorp/go-version v1.5.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
+code.gitea.io/sdk/gitea v0.17.0 h1:8JPBss4+Jf7AE1YcfyiGrngTXE8dFSG3si/bypsTH34=
+code.gitea.io/sdk/gitea v0.17.0/go.mod h1:ndkDk99BnfiUCCYEUhpNzi0lpmApXlwRFqClBlOlEBg=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -61,6 +63,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davidmz/go-pageant v1.0.2 h1:bPblRCh5jGU+Uptpz6LgMZGD5hJoOt7otgT454WvHn0=
+github.com/davidmz/go-pageant v1.0.2/go.mod h1:P2EDDnMqIwG5Rrp05dTRITj9z2zpGcD9efWSkTNKLIE=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -71,6 +75,8 @@ github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0X
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
+github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -140,6 +146,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/hashicorp/go-version v1.5.0 h1:O293SZ2Eg+AAYijkVK3jR786Am1bhDEh2GHT0tIVE5E=
+github.com/hashicorp/go-version v1.5.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -232,7 +240,9 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=

--- a/internal/gitea/gitea.go
+++ b/internal/gitea/gitea.go
@@ -1,9 +1,14 @@
 package gitea
 
+type RepoConfig struct {
+	MonorepoSources []string `mapstructure:"monorepo-folders"`
+}
+
 // OrgConfig contains fields used in releasegen's config.yaml file to configure
 // its behaviour when generating reports about Gitea repositories.
 type OrgConfig struct {
-	Org          string   `mapstructure:"org"`
-	URL          string   `mapstructure:"url"`
-	IgnoredRepos []string `mapstructure:"ignores"`
+	Org          string                `mapstructure:"org"`
+	URL          string                `mapstructure:"url"`
+	IncludeRepos map[string]RepoConfig `mapstructure:"includes"`
+	IgnoredRepos []string              `mapstructure:"ignores"`
 }

--- a/internal/gitea/gitea.go
+++ b/internal/gitea/gitea.go
@@ -1,29 +1,9 @@
 package gitea
 
-import (
-	"code.gitea.io/sdk/gitea"
-)
-
 // OrgConfig contains fields used in releasegen's config.yaml file to configure
 // its behaviour when generating reports about Gitea repositories.
 type OrgConfig struct {
 	Org          string   `mapstructure:"org"`
 	URL          string   `mapstructure:"url"`
 	IgnoredRepos []string `mapstructure:"ignores"`
-
-	gtClient *gitea.Client
-}
-
-// GiteaClient returns either a new instance of the Gitea client, or a
-// previously initialised client.
-func (oc *OrgConfig) GiteaClient() (*gitea.Client, error) {
-	if oc.gtClient == nil {
-		var err error
-		oc.gtClient, err = gitea.NewClient(oc.URL)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return oc.gtClient, nil
 }

--- a/internal/gitea/gitea.go
+++ b/internal/gitea/gitea.go
@@ -1,0 +1,29 @@
+package gitea
+
+import (
+	"code.gitea.io/sdk/gitea"
+)
+
+// OrgConfig contains fields used in releasegen's config.yaml file to configure
+// its behaviour when generating reports about Gitea repositories.
+type OrgConfig struct {
+	Org          string   `mapstructure:"org"`
+	URL          string   `mapstructure:"url"`
+	IgnoredRepos []string `mapstructure:"ignores"`
+
+	gtClient *gitea.Client
+}
+
+// GiteaClient returns either a new instance of the Gitea client, or a
+// previously initialised client.
+func (oc *OrgConfig) GiteaClient() (*gitea.Client, error) {
+	if oc.gtClient == nil {
+		var err error
+		oc.gtClient, err = gitea.NewClient(oc.URL)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return oc.gtClient, nil
+}

--- a/internal/gitea/repo.go
+++ b/internal/gitea/repo.go
@@ -1,0 +1,190 @@
+package gitea
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"code.gitea.io/sdk/gitea"
+	"github.com/gomarkdown/markdown"
+	"github.com/jnsgruk/releasegen/internal/repos"
+)
+
+const giteaReleasesPerRepo = 3
+
+// Repository represents a single repository. Note that this might be a Gitea
+// Repository or it might be a folder in a Gitea Repository if the Repository
+// is a monorepo.
+type Repository struct {
+	Details       repos.RepoDetails
+	org           string // The Gitea Org that owns the repo.
+	client        *gitea.Client
+	defaultBranch string
+	folder        string
+}
+
+// Process populates the Repository with details of its releases, and commits.
+func (r *Repository) Process() error {
+	// Iterate over the releases in the Gitea repo and add them to our repository's details.
+	err := r.processReleases()
+	if err != nil {
+		return err
+	}
+
+	if len(r.Details.Releases) > 0 {
+		// Calculate the number of commits since the latest release.
+		err := r.processCommitsSinceRelease()
+		if err != nil {
+			return err
+		}
+	} else {
+		// If there are no releases, get the latest commit instead.
+		err := r.processCommits()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Populate the repository's README from Gitea, parse any linked snaps or charms.
+	err = r.parseReadme()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// parseReadme is a helper function to fetch the README from a Gitea repository and return
+// its contents as a string.
+func (r *Repository) parseReadme() error {
+	var readmeNames = []string {"README.md", "README.rst"}
+	var giteaReadme []byte
+	for _, rName := range readmeNames { 
+		var err error
+		var fileName string
+		if r.folder == "" {
+			fileName = rName
+		} else {
+			fileName = fmt.Sprintf("%s/%s", r.folder, rName)
+		}
+		giteaReadme, _, err = r.client.GetFile(r.org, r.Details.Name, r.defaultBranch, fileName, false)
+		if err == nil {
+			break
+		}
+	}
+	if len(giteaReadme) == 0 {
+		return errors.New("error getting README for repo")
+	}
+
+	content := string(giteaReadme)
+
+	// Parse contents of README to identify associated snaps, charms.
+	readme := &repos.Readme{Body: content}
+	ctx := context.Background()
+	r.Details.Snap = readme.LinkedSnap(ctx)
+	r.Details.Charm = readme.LinkedCharm(ctx)
+
+	return nil
+}
+
+// processReleases fetches a repository's releases from Gitea, then populates r.Details.Releases
+// with the information in the relevant format for releasegen.
+func (r *Repository) processReleases() error {
+	// This currently gets all releases across the entire repository, even in a
+	// monorepo. It's not clear what happens with releases in a Gitea monorepo -
+	// for example, are they not used at all? Do they all start with the name of
+	// the 'subrepo'?
+
+	isDraft := false
+	isPreRelease := false
+	opts := gitea.ListReleasesOptions{ListOptions: gitea.ListOptions{PageSize: giteaReleasesPerRepo}, IsDraft: &isDraft, IsPreRelease: &isPreRelease}
+
+	releases, _, err := r.client.ListReleases(r.org, r.Details.Name, opts)
+	if err != nil {
+		return errors.New("error listing releases for repo")
+	}
+
+	for _, rel := range releases {
+		r.Details.Releases = append(r.Details.Releases, &repos.Release{
+			ID:         rel.ID,
+			Version:    rel.TagName,
+			Timestamp:  rel.PublishedAt.Unix(),
+			Title:      rel.Title,
+			Body:       renderReleaseBody(rel.Note, r),
+			URL:        rel.URL,
+			CompareURL: fmt.Sprintf("%s/compare/%s...%s", r.Details.URL, rel.TagName, r.defaultBranch),
+		})
+	}
+
+	return nil
+}
+
+// processCommitsSinceRelease calculates the number of commits that have occurred on the default
+// branch of the repository since the last release, and populates the information in r.Details.
+func (r *Repository) processCommitsSinceRelease() error {
+	// This does not currently handle monorepos - see note about releases in
+	// `processReleases`. If there are releases in Gitea with a monorepo, then
+	// this function maybe needs to restrict the commits to ones where the tree
+	// overlaps - but maybe we actually want to know how many commits overall,
+	// because we want to count things like common code being adjusted.
+
+	// Add the commit delta between last release and default branch.
+	latestRelease := r.Details.Releases[len(r.Details.Releases)-1]
+	opts := gitea.ListCommitOptions{ListOptions: gitea.ListOptions{PageSize: giteaReleasesPerRepo}, SHA: latestRelease.Version, Path: ""}
+	commits, _, err := r.client.ListRepoCommits(r.org, r.Details.Name, opts)
+	if err != nil {
+		return errors.New("error getting commits since release")
+	}
+
+	r.Details.NewCommits = len(commits)
+
+	return nil
+}
+
+// processCommits fetches the latest 3 commits to a repository and populates them into the repo
+// struct in the case that there are no releases identified.
+func (r *Repository) processCommits() error {
+	// This does not currently handle monorepos. It's not clear which commits
+	// should be counted in this case - only ones that have a tree that overlaps
+	// with the subfolder? All commits, as now? If there's common code, then
+	// all commits is probably truest to the single-repo meaning, but if there
+	// are commits that are only in a separate charm, then those probably should
+	// not be included.
+
+	opts := gitea.ListCommitOptions{ListOptions: gitea.ListOptions{PageSize: giteaReleasesPerRepo}, SHA: r.defaultBranch, Path: ""}
+
+	// If there are no releases, get the latest commit instead.
+	commits, _, err := r.client.ListRepoCommits(r.org, r.Details.Name, opts)
+	if err != nil {
+		return errors.New("error listing commits for repository")
+	}
+
+	// Iterate over the commits and append them to r.Details.Commits
+	for _, commit := range commits {
+		// Some commits don't have an author.
+		var name string
+		if commit.Author == nil {
+			name = ""
+		} else {
+			name = commit.Author.FullName
+		}
+		r.Details.Commits = append(r.Details.Commits, &repos.Commit{
+			Sha:       commit.CommitMeta.SHA,
+			Author:    name,
+			Timestamp: commit.CommitMeta.Created.Unix(),
+			Message:   renderReleaseBody(commit.RepoCommit.Message, r),
+			URL:       commit.HTMLURL,
+		})
+	}
+
+	return nil
+}
+
+// renderReleaseBody transforms a Markdown string from a Gitea Release into HTML.
+func renderReleaseBody(body string, repo *Repository) string {
+	// Render the Markdown to HTML.
+	md := []byte(body)
+	normalised := markdown.NormalizeNewlines(md)
+
+	return string(markdown.ToHTML(normalised, nil, nil))
+}

--- a/internal/gitea/repo.go
+++ b/internal/gitea/repo.go
@@ -25,20 +25,20 @@ type Repository struct {
 }
 
 // Process populates the Repository with details of its releases, and commits.
-func (r *Repository) Process() error {
+func (repo *Repository) Process() error {
 	// Iterate over the releases in the Gitea repo and add them to our
 	// repository's details.
-	err := r.processReleases()
+	err := repo.processReleases()
 	if err != nil {
 		return err
 	}
 
-	if len(r.Details.Releases) > 0 {
+	if len(repo.Details.Releases) > 0 {
 		// Calculate the number of commits since the latest release.
-		err = r.processCommitsSinceRelease()
+		err = repo.processCommitsSinceRelease()
 	} else {
 		// If there are no releases, get the latest commit instead.
-		err = r.processCommits()
+		err = repo.processCommits()
 	}
 	if err != nil {
 		return err
@@ -46,7 +46,7 @@ func (r *Repository) Process() error {
 
 	// Populate the repository's README from Gitea and parse any linked snaps
 	// or charms.
-	err = r.parseReadme()
+	err = repo.parseReadme()
 	if err != nil {
 		return err
 	}
@@ -56,17 +56,22 @@ func (r *Repository) Process() error {
 
 // parseReadme is a helper function to fetch the README from a Gitea repository
 // and populates any linked Charms or Snaps in r.Details.
-func (r *Repository) parseReadme() error {
+func (repo *Repository) parseReadme() error {
 	names := []string{"README.md", "README.rst"}
 	var bytes []byte
 	for _, name := range names {
 		var err error
-		var fileName string
-		path := name
-		if r.folder != "" {
-			path = path.Join(r.folder, name)
+		fileName := name
+		if repo.folder != "" {
+			fileName = path.Join(repo.folder, fileName)
 		}
-		bytes, _, err = r.client.GetFile(r.org, r.Details.Name, r.defaultBranch, fileName, false)
+		bytes, _, err = repo.client.GetFile(
+			repo.org,
+			repo.Details.Name,
+			repo.defaultBranch,
+			fileName,
+			false,
+		)
 		if err == nil {
 			break
 		}
@@ -77,45 +82,44 @@ func (r *Repository) parseReadme() error {
 
 	content := string(bytes)
 
-	// Parse contents of README to identify associated snaps, charms.
+	// Parse contents of README to identify associated Snaps and Charms.
 	readme := &repos.Readme{Body: content}
 	ctx := context.Background()
-	r.Details.Snap = readme.LinkedSnap(ctx)
-	r.Details.Charm = readme.LinkedCharm(ctx)
+	repo.Details.Snap = readme.LinkedSnap(ctx)
+	repo.Details.Charm = readme.LinkedCharm(ctx)
 
 	return nil
 }
 
 // processReleases fetches a repository's releases from Gitea, then populates
 // r.Details.Releases with the information in the relevant format for releasegen.
-func (r *Repository) processReleases() error {
+func (repo *Repository) processReleases() error {
 	// TODO: This currently gets all releases across the entire repository, even
 	// in a monorepo. It's not clear what happens with releases in a Gitea
 	// monorepo - for example, are they not used at all? Do they all start with
 	// the name of the 'subrepo'?
 
 	opts := gitea.ListReleasesOptions{
-		ListOptions: gitea.ListOptions{PageSize: releasesPerRepo},
-		IsDraft: gitea.OptionalBool(false),
-		IsPreRelease: gitea.OptionalBool(false)
+		ListOptions:  gitea.ListOptions{PageSize: releasesPerRepo},
+		IsDraft:      gitea.OptionalBool(false),
+		IsPreRelease: gitea.OptionalBool(false),
 	}
 
-	releases, _, err := r.client.ListReleases(r.org, r.Details.Name, opts)
+	releases, _, err := repo.client.ListReleases(repo.org, repo.Details.Name, opts)
 	if err != nil {
 		return err
 	}
 
 	for _, rel := range releases {
-		r.Details.Releases = append(r.Details.Releases, &repos.Release{
-			ID:         rel.ID,
-			Version:    rel.TagName,
-			Timestamp:  rel.PublishedAt.Unix(),
-			Title:      rel.Title,
-			Body:       renderReleaseBody(rel.Note, r),
-			URL:        rel.URL,
+		repo.Details.Releases = append(repo.Details.Releases, &repos.Release{
+			ID:        rel.ID,
+			Version:   rel.TagName,
+			Timestamp: rel.PublishedAt.Unix(),
+			Title:     rel.Title,
+			Body:      renderReleaseBody(rel.Note, repo),
+			URL:       rel.URL,
 			CompareURL: fmt.Sprintf(
-				"%s/compare/%s...%s", r.Details.URL, rel.TagName, r.defaultBranch
-			),
+				"%s/compare/%s...%s", repo.Details.URL, rel.TagName, repo.defaultBranch),
 		})
 	}
 
@@ -125,37 +129,37 @@ func (r *Repository) processReleases() error {
 // processCommitsSinceRelease calculates the number of commits that have
 // occurred on the default branch of the repository since the last release, and
 // populates the information in r.Details.
-func (r *Repository) processCommitsSinceRelease() error {
+func (repo *Repository) processCommitsSinceRelease() error {
 	// TODO: This does not currently handle monorepos - see note about releases
 	// in `processReleases`. If there are releases in Gitea with a monorepo,
 	// then this function maybe needs to restrict the commits to ones where the
 	// tree overlaps - but maybe we actually want to know how many commits
 	// overall, because we want to count things like common code being adjusted.
 
-	if !len(r.Details.Releases) {
-		return errors.New("processCommitsSinceRelease cannot be called if there are no releases!")
+	if len(repo.Details.Releases) == 0 {
+		return errors.New("processCommitsSinceRelease must not be called without releases!")
 	}
 
 	// Add the commit delta between last release and default branch.
-	latestRelease := r.Details.Releases[len(r.Details.Releases)-1]
+	latestRelease := repo.Details.Releases[len(repo.Details.Releases)-1]
 	opts := gitea.ListCommitOptions{
-		ListOptions: gitea.ListOptions{PageSize: giteaReleasesPerRepo},
-		SHA: latestRelease.Version,
-		Path: ""
+		ListOptions: gitea.ListOptions{PageSize: releasesPerRepo},
+		SHA:         latestRelease.Version,
+		Path:        "",
 	}
-	commits, _, err := r.client.ListRepoCommits(r.org, r.Details.Name, opts)
+	commits, _, err := repo.client.ListRepoCommits(repo.org, repo.Details.Name, opts)
 	if err != nil {
 		return err
 	}
 
-	r.Details.NewCommits = len(commits)
+	repo.Details.NewCommits = len(commits)
 
 	return nil
 }
 
 // processCommits fetches the latest commits to a repository and populates them
 // into the repo struct in the case that there are no releases identified.
-func (r *Repository) processCommits() error {
+func (repo *Repository) processCommits() error {
 	// TODO: This does not currently handle monorepos. It's not clear which
 	// commits should be counted in this case - only ones that have a tree that
 	// overlaps with the subfolder? All commits, as now? If there's common code,
@@ -164,12 +168,12 @@ func (r *Repository) processCommits() error {
 	// should not be included.
 
 	opts := gitea.ListCommitOptions{
-		ListOptions: gitea.ListOptions{PageSize: giteaReleasesPerRepo},
-		SHA: r.defaultBranch,
-		Path: ""
+		ListOptions: gitea.ListOptions{PageSize: releasesPerRepo},
+		SHA:         repo.defaultBranch,
+		Path:        "",
 	}
 
-	commits, _, err := r.client.ListRepoCommits(r.org, r.Details.Name, opts)
+	commits, _, err := repo.client.ListRepoCommits(repo.org, repo.Details.Name, opts)
 	if err != nil {
 		return err
 	}
@@ -181,11 +185,11 @@ func (r *Repository) processCommits() error {
 		if commit.Author != nil {
 			name = commit.Author.FullName
 		}
-		r.Details.Commits = append(r.Details.Commits, &repos.Commit{
+		repo.Details.Commits = append(repo.Details.Commits, &repos.Commit{
 			Sha:       commit.CommitMeta.SHA,
 			Author:    name,
 			Timestamp: commit.CommitMeta.Created.Unix(),
-			Message:   renderReleaseBody(commit.RepoCommit.Message, r),
+			Message:   renderReleaseBody(commit.RepoCommit.Message, repo),
 			URL:       commit.HTMLURL,
 		})
 	}

--- a/internal/gitea/repo.go
+++ b/internal/gitea/repo.go
@@ -105,7 +105,11 @@ func (repo *Repository) processReleases() error {
 		IsPreRelease: gitea.OptionalBool(false),
 	}
 
-	releases, _, err := repo.client.ListReleases(repo.org, repo.Details.Name, opts)
+	source := repo.Details.Name
+	if repo.Details.Monorepo != "" {
+		source = repo.Details.Monorepo
+	}
+	releases, _, err := repo.client.ListReleases(repo.org, source, opts)
 	if err != nil {
 		return err
 	}
@@ -147,7 +151,11 @@ func (repo *Repository) processCommitsSinceRelease() error {
 		SHA:         latestRelease.Version,
 		Path:        "",
 	}
-	commits, _, err := repo.client.ListRepoCommits(repo.org, repo.Details.Name, opts)
+	source := repo.Details.Name
+	if repo.Details.Monorepo != "" {
+		source = repo.Details.Monorepo
+	}
+	commits, _, err := repo.client.ListRepoCommits(repo.org, source, opts)
 	if err != nil {
 		return err
 	}
@@ -173,7 +181,11 @@ func (repo *Repository) processCommits() error {
 		Path:        "",
 	}
 
-	commits, _, err := repo.client.ListRepoCommits(repo.org, repo.Details.Name, opts)
+	source := repo.Details.Name
+	if repo.Details.Monorepo != "" {
+		source = repo.Details.Monorepo
+	}
+	commits, _, err := repo.client.ListRepoCommits(repo.org, source, opts)
 	if err != nil {
 		return err
 	}

--- a/internal/gitea/repo.go
+++ b/internal/gitea/repo.go
@@ -33,16 +33,13 @@ func (r *Repository) Process() error {
 
 	if len(r.Details.Releases) > 0 {
 		// Calculate the number of commits since the latest release.
-		err := r.processCommitsSinceRelease()
-		if err != nil {
-			return err
-		}
+		err = r.processCommitsSinceRelease()
 	} else {
 		// If there are no releases, get the latest commit instead.
-		err := r.processCommits()
-		if err != nil {
-			return err
-		}
+		err = r.processCommits()
+	}
+	if err != nil {
+		return err
 	}
 
 	// Populate the repository's README from Gitea, parse any linked snaps or charms.

--- a/internal/gitea/repo.go
+++ b/internal/gitea/repo.go
@@ -180,8 +180,7 @@ func (r *Repository) processCommits() error {
 // renderReleaseBody transforms a Markdown string from a Gitea Release into HTML.
 func renderReleaseBody(body string, repo *Repository) string {
 	// Render the Markdown to HTML.
-	md := []byte(body)
-	normalised := markdown.NormalizeNewlines(md)
+	normalised := markdown.NormalizeNewlines([]byte(body))
 
 	return string(markdown.ToHTML(normalised, nil, nil))
 }

--- a/internal/gitea/team.go
+++ b/internal/gitea/team.go
@@ -94,7 +94,7 @@ func processRepo(gtClient *gitea.Client, org string, oRepo *gitea.Repository) *R
 
 	err := repo.Process()
 	if err != nil {
-		log.Printf("error populating repo '%s' from gitea: %s", repo.Details.Name, err.Error())
+		log.Printf("error populating repo '%s' from gitea: %v", repo.Details.Name, err)
 	}
 
 	return repo

--- a/internal/gitea/team.go
+++ b/internal/gitea/team.go
@@ -18,7 +18,7 @@ const maxPages = 100    // Give up after getting this many pages.
 func FetchOrgRepos(org OrgConfig) ([]repos.RepoDetails, error) {
 	orgRepos := []repos.RepoDetails{}
 
-	client, err := org.GiteaClient()
+	client, err := gitea.NewClient(org.URL)
 	if err != nil {
 		return nil, fmt.Errorf("error creating gitea client: %w", err)
 	}

--- a/internal/gitea/team.go
+++ b/internal/gitea/team.go
@@ -1,0 +1,145 @@
+package gitea
+
+import (
+	"fmt"
+	"log"
+	"slices"
+	"strings"
+
+	"code.gitea.io/sdk/gitea"
+	"github.com/jnsgruk/releasegen/internal/repos"
+)
+
+const giteaPerPage = 10
+
+// FetchOrgRepos creates a slice of RepoDetails types representing the repos
+// owned by the Gitea org.
+func FetchOrgRepos(org OrgConfig) ([]repos.RepoDetails, error) {
+	orgRepos := []repos.RepoDetails{}
+
+	gtClient, err := org.GiteaClient()
+	if err != nil {
+		return nil, fmt.Errorf("error creating gitea client: %s", err)
+	}
+
+	// Lists the gitea repositories in the org.
+	for currentPage := 1; ; {
+		log.Printf("Getting page %d\n", currentPage)
+
+		opts := gitea.ListReposOptions{ListOptions: gitea.ListOptions{Page: currentPage, PageSize: giteaPerPage}}
+		gtRepos, resp, err := gtClient.ListUserRepos(org.Org, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error listing repositories for gitea org: %s", org.Org)
+		}
+		if currentPage == resp.LastPage {
+			break
+		}
+
+		// Iterate over repositories, populating release info for each.
+		for _, oRepo := range gtRepos {
+			r := oRepo
+			// Check if the name of the repository is in the ignore list or private or archived, or already processed.
+			if slices.Contains(org.IgnoredRepos, r.Name) || r.Private || r.Archived || repos.RepoInSlice(orgRepos, r.Name) {
+				continue
+			}
+
+			// This might actually be a monorepo. We don't have a definitive way to
+			// know that, for now, assume it is if there is a "charms" folder at the
+			// top level.
+			// TODO: Figure out some better way of determining this. Maybe it just
+			// has to be in the configuration file? If it is something like this,
+			// should we also look for a "snaps" folder as well?
+			_, _, err = gtClient.GetFile(org.Org, r.Name, r.DefaultBranch, "charms", false)
+			is_monorepo := err == nil
+
+			if is_monorepo {
+				repos := processFromMonoRepo(gtClient, org.Org, r)
+				for _, repo := range repos {
+					if len(repo.Details.Releases) > 0 {
+						orgRepos = append(orgRepos, repo.Details)
+					}
+				}
+			} else {
+				repo := processRepo(gtClient, org.Org, r)
+				if len(repo.Details.Releases) > 0 {
+					orgRepos = append(orgRepos, repo.Details)
+				}
+			}
+		}
+
+		currentPage = resp.NextPage
+	}	
+
+	return orgRepos, nil
+}
+
+// Process a single (non-mono) repo.
+func processRepo(gtClient *gitea.Client, org string, oRepo *gitea.Repository) *Repository {
+	repo := &Repository{
+		Details: repos.RepoDetails{
+			Name: oRepo.Name,
+			URL:  oRepo.HTMLURL,
+		},
+		org:           org,
+		client:        gtClient,
+		defaultBranch: oRepo.DefaultBranch,
+		folder:        "",
+	}
+
+	log.Printf("processing gitea repo: %s/%s\n", repo.org, repo.Details.Name)
+
+	err := repo.Process()
+	if err != nil {
+		log.Printf("error populating repo '%s' from gitea: %s", repo.Details.Name, err.Error())
+	}
+
+	return repo
+}
+
+// Process multiple 'repositories' from a monorepo.
+func processFromMonoRepo(gtClient *gitea.Client, org string, oRepo *gitea.Repository) []*Repository {
+	var subrepos []*Repository 
+
+	// For now, this assumes that every 'repo' in the monorepo is in a folder
+	// called "charms". Maybe there should be a list to check in the config,
+	// or maybe we should just hardcode some others, like "snaps", as well.
+	// There does not seem to be an API to get a sub-tree, so this gets the
+	// entire tree even though we only care about a small part of it.
+	tree, _, err := gtClient.GetTrees(org, oRepo.Name, oRepo.DefaultBranch, true)
+	if err != nil {
+		log.Printf("error listing monorepo '%s': %s", oRepo.Name, err.Error())
+		return subrepos
+	}
+
+	for _, entry := range tree.Entries {
+		path := entry.Path
+
+		parts := strings.Split(path, "/")
+		if len(parts) > 2 || parts[0] != "charms" {
+			continue
+		}
+		charmName := parts[1]
+
+		repo := &Repository{
+			Details: repos.RepoDetails{
+				Name: charmName,
+				URL:  entry.URL,
+			},
+			org:           org,
+			client:        gtClient,
+			defaultBranch: oRepo.DefaultBranch,
+			folder:        entry.Path,
+		}
+
+		log.Printf("processing gitea repo: %s/%s\n", repo.org, repo.Details.Name)
+
+		err := repo.Process()
+		if err != nil {
+			log.Printf("error populating repo '%s' from gitea: %s", repo.Details.Name, err.Error())
+		}
+
+		subrepos = append(subrepos, repo)
+	}
+
+	return subrepos
+}

--- a/internal/releasegen/config.go
+++ b/internal/releasegen/config.go
@@ -3,6 +3,7 @@ package releasegen
 import (
 	"github.com/jnsgruk/releasegen/internal/github"
 	"github.com/jnsgruk/releasegen/internal/launchpad"
+	"github.com/jnsgruk/releasegen/internal/gitea"
 )
 
 // Config represents the user provided configuration file.
@@ -21,4 +22,5 @@ type TeamConfig struct {
 	Name            string             `mapstructure:"name"`
 	GithubConfig    []github.OrgConfig `mapstructure:"github"`
 	LaunchpadConfig launchpad.Config   `mapstructure:"launchpad"`
+	GiteaConfig	    []gitea.OrgConfig    `mapstructure:"gitea"`
 }

--- a/internal/releasegen/config.go
+++ b/internal/releasegen/config.go
@@ -1,9 +1,9 @@
 package releasegen
 
 import (
+	"github.com/jnsgruk/releasegen/internal/gitea"
 	"github.com/jnsgruk/releasegen/internal/github"
 	"github.com/jnsgruk/releasegen/internal/launchpad"
-	"github.com/jnsgruk/releasegen/internal/gitea"
 )
 
 // Config represents the user provided configuration file.
@@ -22,5 +22,5 @@ type TeamConfig struct {
 	Name            string             `mapstructure:"name"`
 	GithubConfig    []github.OrgConfig `mapstructure:"github"`
 	LaunchpadConfig launchpad.Config   `mapstructure:"launchpad"`
-	GiteaConfig	    []gitea.OrgConfig    `mapstructure:"gitea"`
+	GiteaConfig     []gitea.OrgConfig  `mapstructure:"gitea"`
 }

--- a/internal/releasegen/team.go
+++ b/internal/releasegen/team.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jnsgruk/releasegen/internal/github"
 	"github.com/jnsgruk/releasegen/internal/launchpad"
+	"github.com/jnsgruk/releasegen/internal/gitea"
 	"github.com/jnsgruk/releasegen/internal/repos"
 )
 
@@ -23,7 +24,7 @@ type Team struct {
 	githubToken string
 }
 
-// Process populates a given team with the details of its Github/Launchpad repos.
+// Process populates a given team with the details of its Github/Launchpad/Gitea repos.
 func (t *Team) Process() error {
 	log.Printf("processing team: %s", t.config.Name)
 
@@ -52,6 +53,18 @@ func (t *Team) Process() error {
 		}
 
 		t.Details.Repos = append(t.Details.Repos, lpRepos...)
+	}
+
+	// Iterate over the Gitea orgs.
+	for _, org := range t.config.GiteaConfig {
+		log.Printf("processing gitea org: %s\n", org.Org)
+	
+		odRepos, err := gitea.FetchOrgRepos(org)
+		if err != nil {
+			return fmt.Errorf("error populating gitea repos: %w", err)
+		}
+
+		t.Details.Repos = append(t.Details.Repos, odRepos...)
 	}
 
 	// Sort the repos by the last released.

--- a/internal/releasegen/team.go
+++ b/internal/releasegen/team.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"sort"
 
+	"github.com/jnsgruk/releasegen/internal/gitea"
 	"github.com/jnsgruk/releasegen/internal/github"
 	"github.com/jnsgruk/releasegen/internal/launchpad"
-	"github.com/jnsgruk/releasegen/internal/gitea"
 	"github.com/jnsgruk/releasegen/internal/repos"
 )
 
@@ -58,7 +58,7 @@ func (t *Team) Process() error {
 	// Iterate over the Gitea orgs.
 	for _, org := range t.config.GiteaConfig {
 		log.Printf("processing gitea org: %s\n", org.Org)
-	
+
 		odRepos, err := gitea.FetchOrgRepos(org)
 		if err != nil {
 			return fmt.Errorf("error populating gitea repos: %w", err)

--- a/internal/repos/repo.go
+++ b/internal/repos/repo.go
@@ -23,7 +23,7 @@ type Repository interface {
 	Process() error
 }
 
-// Release refers to either Github Release, or a Launchpad Tag.
+// Release refers to either Github Release, a Launchpad Tag, or a Gitea Release.
 type Release struct {
 	ID         int64  `json:"id"`
 	Version    string `json:"version"`

--- a/internal/repos/repo.go
+++ b/internal/repos/repo.go
@@ -9,6 +9,7 @@ import (
 // RepoDetails represents the serialisable form of a Repository for the Report.
 type RepoDetails struct {
 	Name       string           `json:"name"`
+	Monorepo   string           `json:"monorepo"`
 	NewCommits int              `json:"newCommits"`
 	URL        string           `json:"url"`
 	Releases   []*Release       `json:"releases"`


### PR DESCRIPTION
This PR extends the GitHub and Launchpad support to also include Gitea repositories, such as opendev.org.

A pre-commit config and basic CI runner is also added.

For Gitea, there is also basic monorepo support. This probably should be handled in GitHub and Launchpad as well, but I wanted to have a more minimal approach for this first attempt.

### TODO

* [ ] At the moment it goes through all of the repositories in an organisation. For opendev.org/openstack, this is over 1k repositories, most of which are probably not of interest. Gitea has a Team construct, but I can't find that in use on opendev.org. The OpenStack charms are moving to monorepos, so perhaps individual repositories should be in the config rather than the organisation as a whole. I've reached out to James Page for advice.
* [ ] A monorepo doesn't have a clear "this is a monorepo" indicator. For now, I've assumed that it is one if there is a top-level "charms" folder. If we end up listing individual repositories in the config, then this is easily solved by adding a `monorepo` flag there. Otherwise, there are probably better heuristics, and we should perhaps be looking for a "snaps" folder as well (and maybe the "libs" folder?).
* [ ] I'm not clear on how we are using Gitea Releases on opendev.org in a monorepo. For the output of this script, should each individual 'sub repo' in the monorepo have a separate releases count? How does "commits since last release" work in that context? What about the number of commits when there are no releases? I think these are questions for Jon once the PR is in a state that it can be opened against the remote.
* [ ] The GitHub code gets CI information from a badge in the README. This could be retrieved from Zuul (assuming that if you're using Gitea you're using Zuul), I think.